### PR TITLE
Backport to 1.3.1, Added the Rush Multiplier to the Preset Manager

### DIFF
--- a/Kerbal_Construction_Time/KCT_GUI_BuildList.cs
+++ b/Kerbal_Construction_Time/KCT_GUI_BuildList.cs
@@ -1101,6 +1101,8 @@ namespace KerbalConstructionTime
             KCT_BuildListVessel b = KCT_Utilities.FindBLVesselByID(IDSelected);
             GUILayout.BeginVertical();
             string launchSite = b.launchSite;
+            float rbMultiplier = KCT_PresetManager.Instance.ActivePreset.generalSettings.RushMultiplier;
+
             if (launchSite == "LaunchPad")
             {
                 if (b.launchSiteID >= 0)
@@ -1111,6 +1113,7 @@ namespace KerbalConstructionTime
             KCT_Recon_Rollout rollout = KCT_GameStates.ActiveKSC.GetReconRollout(KCT_Recon_Rollout.RolloutReconType.Rollout, launchSite);
             bool onPad = rollout != null && rollout.AsBuildItem().IsComplete() && rollout.associatedID == b.id.ToString();
             //This vessel is rolled out onto the pad
+            /* 1.4 Addition
             if (!onPad && GUILayout.Button("Select LaunchSite"))
             {
                 launchSites = KCT_Utilities.GetLaunchSites(b.type == KCT_BuildListVessel.ListType.VAB);
@@ -1126,6 +1129,7 @@ namespace KerbalConstructionTime
                     PopupDialog.SpawnPopupDialog(new MultiOptionDialog("KCTNoLaunchsites", "No launch sites available to choose from. Try visiting an editor first.", "No Launch Sites", null, new DialogGUIButton("OK", () => { })), false, HighLogic.UISkin);
                 }
             }
+            */
             if (!onPad && GUILayout.Button("Scrap"))
             {
                 InputLockManager.SetControlLock(ControlTypes.KSC_ALL, "KCTPopupLock");
@@ -1203,15 +1207,15 @@ namespace KerbalConstructionTime
             }
             if (!b.isFinished 
                 && (KCT_PresetManager.Instance.ActivePreset.generalSettings.MaxRushClicks == 0 || b.rushBuildClicks < KCT_PresetManager.Instance.ActivePreset.generalSettings.MaxRushClicks) 
-                && GUILayout.Button("Rush Build 10%\n√" + Math.Round(0.2 * b.GetTotalCost())))
+                && GUILayout.Button("Rush Build 10%\n√" + Math.Round(rbMultiplier * b.GetTotalCost())))
             {
                 double cost = b.GetTotalCost();
-                cost *= 0.2;
+                double rush = cost * rbMultiplier;
                 double remainingBP = b.buildPoints - b.progress;
-                if (Funding.Instance.Funds >= cost)
+                if (Funding.Instance.Funds >= rush)
                 {
                     b.AddProgress(remainingBP * 0.1);
-                    KCT_Utilities.SpendFunds(cost, TransactionReasons.None);
+                    KCT_Utilities.SpendFunds(rush, TransactionReasons.None);
                     ++b.rushBuildClicks;
                 }
 

--- a/Kerbal_Construction_Time/KCT_PresetManager.cs
+++ b/Kerbal_Construction_Time/KCT_PresetManager.cs
@@ -322,6 +322,8 @@ namespace KerbalConstructionTime
         public string StartingPoints = "15,15,45"; //Career, Science, and Sandbox modes
         [Persistent]
         public int MaxRushClicks = 0;
+        [Persistent]
+        public float RushMultiplier = 0.5f;
     }
 
     public class KCT_Preset_Time : ConfigNodeStorage

--- a/Kerbal_Construction_Time/KCT_Utilities.cs
+++ b/Kerbal_Construction_Time/KCT_Utilities.cs
@@ -530,10 +530,12 @@ namespace KerbalConstructionTime
         {
             return HighLogic.CurrentGame.Mode == Game.Modes.CAREER;
         }
+        /* 1.4 Addition
         public static bool CurrentGameIsMission()
         {
             return HighLogic.CurrentGame.Mode == Game.Modes.MISSION || HighLogic.CurrentGame.Mode == Game.Modes.MISSION_BUILDER;
         }
+        */
 
         public static void AddScienceWithMessage(float science, TransactionReasons reason)
         {
@@ -843,13 +845,14 @@ namespace KerbalConstructionTime
             return spentPoints;
         }
 
-
+        /* 1.4 Addition
         public static List<string> GetLaunchSites(bool isVAB)
         {
             EditorDriver.editorFacility = isVAB ? EditorFacility.VAB : EditorFacility.SPH;
             typeof(EditorDriver).GetMethod("setupValidLaunchSites", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)?.Invoke(null, null);
             return EditorDriver.ValidLaunchSites;
         }
+        */
 
         private static bool? _KSCSwitcherInstalled = null;
         public static bool KSCSwitcherInstalled
@@ -1395,6 +1398,7 @@ namespace KerbalConstructionTime
 
                 EditorLogic.fetch.launchBtn.onClick.AddListener(() => { KerbalConstructionTime.ShowLaunchAlert(null); });
 
+                /* 1.4 Addition
                 //delete listeners to the launchsite specific buttons
                 UILaunchsiteController controller = UnityEngine.Object.FindObjectOfType<UILaunchsiteController>();
 
@@ -1415,16 +1419,18 @@ namespace KerbalConstructionTime
                         }
                     }
                 }
+                */
             }
             else
             {
                 InputLockManager.SetControlLock(ControlTypes.EDITOR_LAUNCH, "KCTLaunchLock");
-
+                /* 1.4 Addition
                 UILaunchsiteController controller = UnityEngine.Object.FindObjectOfType<UILaunchsiteController>();
                 if (controller != null)
                 {
                     controller.locked = true;
                 }
+                */
             }
         }
     }

--- a/Kerbal_Construction_Time/KerbalConstructionTime.cs
+++ b/Kerbal_Construction_Time/KerbalConstructionTime.cs
@@ -39,10 +39,12 @@ namespace KerbalConstructionTime
     {
         public override void OnSave(ConfigNode node)
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             // Boolean error = false;
             KCTDebug.Log("Writing to persistence.");
             base.OnSave(node);
@@ -71,10 +73,12 @@ namespace KerbalConstructionTime
         {
             
             base.OnLoad(node);
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             KCTDebug.Log("Reading from persistence.");
             KCT_GameStates.KSCs.Clear();
             KCT_GameStates.ActiveKSC = null;
@@ -151,19 +155,23 @@ namespace KerbalConstructionTime
 
         private void OnGUI()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             KCT_GUI.SetGUIPositions();
         }
 
         public void Awake()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             KCTDebug.Log("Awake called");
             KCT_GameStates.erroredDuringOnLoad.OnLoadStart();
             KCT_GameStates.PersistenceLoaded = false;
@@ -207,10 +215,12 @@ namespace KerbalConstructionTime
 
         public void Start()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
 
             KCTDebug.Log("Start called");
 
@@ -382,10 +392,12 @@ namespace KerbalConstructionTime
         private static bool ratesUpdated = false;
         public void FixedUpdate()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
 
             double lastUT = KCT_GameStates.UT > 0 ? KCT_GameStates.UT : Planetarium.GetUniversalTime();
             KCT_GameStates.UT = Planetarium.GetUniversalTime();
@@ -541,10 +553,12 @@ namespace KerbalConstructionTime
 
         public void LateUpdate()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             // FIXME really should run this only once, and then again on techlist change.
             // For now, spam per frame
             if (KSP.UI.Screens.RDController.Instance != null)
@@ -575,10 +589,12 @@ namespace KerbalConstructionTime
 
         public static void DelayedStart()
         {
+            /* 1.4 Addition
             if (KCT_Utilities.CurrentGameIsMission())
             {
                 return;
             }
+            */
             KCTDebug.Log("DelayedStart start");
             if (KCT_PresetManager.Instance?.ActivePreset == null || !KCT_PresetManager.Instance.ActivePreset.generalSettings.Enabled)
                 return;

--- a/Kerbal_Construction_Time/KerbalConstructionTime.csproj
+++ b/Kerbal_Construction_Time/KerbalConstructionTime.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>obj\Debug\</OutputPath>
+    <OutputPath>..\GameData\KerbalConstructionTime\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -39,23 +39,32 @@
     <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>D:\SteamLibrary\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="MagiCore">
       <HintPath>..\..\MagiCore\MagiCore\obj\Release\MagiCore.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <Reference Include="System">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>D:\SteamLibrary\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>D:\SteamLibrary\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -92,10 +101,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"C:\Users\magico13\Desktop\KSP_Modding\Tools\pdb2mdb\pdb2mdb.exe" "$(TargetFileName)"
-xcopy /Y "$(TargetPath)" "D:\SteamLibrary\SteamApps\common\Kerbal Space Program\GameData\$(TargetName)\"
-xcopy /Y "$(TargetDir)$(TargetName).pdb" "D:\SteamLibrary\SteamApps\common\Kerbal Space Program\GameData\$(TargetName)\"
-xcopy /Y "$(TargetDir)$(TargetName).dll.mdb" "D:\SteamLibrary\SteamApps\common\Kerbal Space Program\GameData\$(TargetName)\"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets. -->

--- a/Kerbal_Construction_Time/Properties/VersionInfo.cs
+++ b/Kerbal_Construction_Time/Properties/VersionInfo.cs
@@ -1,2 +1,2 @@
-﻿[assembly: System.Reflection.AssemblyVersion("1.3.5.91")]
-[assembly: System.Reflection.AssemblyFileVersion("1.3.5.91")]
+﻿[assembly: System.Reflection.AssemblyVersion("1.4.1.00")]
+[assembly: System.Reflection.AssemblyFileVersion("1.4.1.00")]


### PR DESCRIPTION
* The Rush Multiplier works as a preset and affects the overall cost of the Rush
* Backport of the latest version to work with 1.3.1, though it is probably unnecessary and should have just prepared it for 1.4.5.